### PR TITLE
I deleted warnings with qml and clangd autoformat

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -14,7 +14,7 @@ require("lazy").setup({
 		-- { import = "lazyvim.plugins.extras.lang.typescript" },
     { import = "lazyvim.plugins.extras.lang.json" },
 		{ import = "lazyvim.plugins.extras.ui.mini-animate" },
-		{ import = "lazyvim.plugins.extras.lang.clangd" },
+		-- { import = "lazyvim.plugins.extras.lang.clangd" },
 		-- { import = "lazyvim.plugins.extras.lang.cmake" },
 		-- import/override with your plugins
 		{ import = "plugins" },

--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -2,25 +2,6 @@ return {
 	{
 		"neovim/nvim-lspconfig",
 		---@class PluginLspOpts
-		opts = {
-			autoformat = false,
-			---@type lspconfig.options
-			servers = {
-				clangd = {
-					cmd = {
-						"clangd",
-						"--background-index",
-						"--completion-style=detailed",
-						"--clang-tidy",
-						"--fallback-style=google",
-						"--function-arg-placeholders",
-						"--header-insertion=never",
-						"-j=4",
-					},
-				},
-				qmlls = {},
-        qml_lsp = {},
-			},
-		},
+
 	},
 }

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -11,7 +11,7 @@ return {
 				"markdown",
 				"markdown_inline",
 				"python",
-				"qmljs",
+				-- "qmljs",
 				"regex",
 				"vim",
 				"yaml",

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,3 +1,3 @@
-indent_type = "Tabs"
-indent_width = 1
+indent_type = "Spaces"
+indent_width = 4
 column_width = 120


### PR DESCRIPTION
if there is a problem with autoformating, we have to edit lazy.lua to disable autoformat with vim.g.autoformat instead of nvim-lspconfig.opts.autoformat, but I deleted whole clangd, so this should still work